### PR TITLE
fix: remove redundant null check in GetNewsAndLinksByUrlHandler

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Newss/GetNewsAndLinksByUrl/GetNewsAndLinksByUrlHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/GetNewsAndLinksByUrl/GetNewsAndLinksByUrlHandler.cs
@@ -87,13 +87,6 @@ namespace Streetcode.BLL.MediatR.Newss.GetNewsAndLinksByUrl
             newsDTOWithUrls.NextNewsUrl = nextNewsLink;
             newsDTOWithUrls.PrevNewsUrl = prevNewsLink;
 
-            if (newsDTOWithUrls is null)
-            {
-                string errorMsg = $"No news by entered Url - {url}";
-                _logger.LogError(request, errorMsg);
-                return Result.Fail(errorMsg);
-            }
-
             return Result.Ok(newsDTOWithUrls);
         }
     }


### PR DESCRIPTION
### Changes
- Removed unnecessary null check for `newsDTOWithUrls` object as it can never be null after instantiation with `new` operator

### Why
- The removed check was redundant since:
    1. The object is created using the `new` operator which cannot return null
    2. Object properties are initialized immediately after creation
    3. Similar error handling already exists earlier in the code

### Testing
- Existing functionality remains unchanged
- No regression in error handling as the primary validation is preserved

### Additional Notes
- This change improves code clarity by removing dead code
- No breaking changes introduced