### PR TITLE
Replace '.Count() == 0' with '! .Any()' for better performance

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Media/Image/GetByStreetcodeId/GetImageByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Media/Image/GetByStreetcodeId/GetImageByStreetcodeIdHandler.cs
@@ -31,7 +31,7 @@ public class GetImageByStreetcodeIdHandler : IRequestHandler<GetImageByStreetcod
             f => f.Streetcodes.Any(s => s.Id == request.StreetcodeId),
             include: q => q.Include(img => img.ImageDetails))).OrderBy(img => img.ImageDetails?.Alt);
 
-        if (images is null || images.Count() == 0)
+        if (images is null || !images.Any())
         {
             string errorMsg = $"Cannot find an image with the corresponding streetcode id: {request.StreetcodeId}";
             _logger.LogError(request, errorMsg);

--- a/Streetcode/Streetcode.WebApi/Utils/SoftDeletingUtils.cs
+++ b/Streetcode/Streetcode.WebApi/Utils/SoftDeletingUtils.cs
@@ -20,7 +20,7 @@ public class SoftDeletingUtils
             include: s => s.Include(x => x.Observers)
                            .Include(x => x.Targets));
 
-        if (streetcodes is null || streetcodes.Count() == 0)
+        if (streetcodes is null || !streetcodes.Any())
         {
             return;
         }


### PR DESCRIPTION
## Summary of issue

Performance improvement needed by using a more optimal LINQ method.

## Summary of change

Replaced instances of `.Count() == 0` with `! .Any()` to improve performance of LINQ operations.