### PR TITLE
refactor/19: refactor LogError method parameter for clarity

### DIFF
--- a/Streetcode/Streetcode.BLL/Services/Logging/LoggerService.cs
+++ b/Streetcode/Streetcode.BLL/Services/Logging/LoggerService.cs
@@ -32,11 +32,11 @@ namespace Streetcode.BLL.Services.Logging
             _logger.Debug($"{msg}");
         }
 
-        public void LogError(object request, string erroMsg)
+        public void LogError(object request, string errorMessage)
         {
             string requestType = request.GetType().ToString();
             string requestClass = requestType.Substring(requestType.LastIndexOf('.') + 1);
-            _logger.Error($"{requestClass} handled with the error: {erroMsg}");
+            _logger.Error($"{requestClass} handled with the error: {errorMessage}");
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/Services/Logging/LoggerService.cs
+++ b/Streetcode/Streetcode.BLL/Services/Logging/LoggerService.cs
@@ -32,11 +32,11 @@ namespace Streetcode.BLL.Services.Logging
             _logger.Debug($"{msg}");
         }
 
-        public void LogError(object request, string errorMessage)
+        public void LogError(object request, string errorMsg)
         {
             string requestType = request.GetType().ToString();
             string requestClass = requestType.Substring(requestType.LastIndexOf('.') + 1);
-            _logger.Error($"{requestClass} handled with the error: {errorMessage}");
+            _logger.Error($"{requestClass} handled with the error: {errorMsg}");
         }
     }
 }


### PR DESCRIPTION
dev

## Code reviewers

- [x] @DenysSaiuk 
- [x] @ErikParrotAI 

## Summary of issue

Rename parameter 'erroMsg' to 'errorMsg' to match the interface declaration.
#19 

## Summary of change

Updated the `LogError` method in `LoggerService.cs` to change the parameter name from `erroMsg` to `errorMessage`. Adjusted the logging statement to use the new parameter name, ensuring accurate error message logging.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
