### PR TITLE
Add unit tests for Toponym query handlers

### DIFF
--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetAll/GetAllToponymsHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetAll/GetAllToponymsHandlerTests.cs
@@ -1,0 +1,133 @@
+using System.Linq.Expressions;
+using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Streetcode.BLL.DTO.Toponyms;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Toponyms.GetAll;
+using Streetcode.DAL.Entities.Toponyms;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.MediatRTests.Toponyms.GetAll;
+
+public class GetAllToponymsHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<ILoggerService> _loggerMock = new();
+    private readonly GetAllToponymsHandler _handler;
+
+    public GetAllToponymsHandlerTests()
+    {
+        _handler = new GetAllToponymsHandler(
+            _repositoryWrapperMock.Object,
+            _mapperMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_WhenToponymsExist()
+    {
+        // Arrange
+        var (entities, mappedDtos) = CreateValidToponymEntitiesAndDtos();
+        SetupMocksForToponyms(entities, mappedDtos);
+
+        var query = new GetAllToponymsQuery(
+            new GetAllToponymsRequestDTO { Title = null, Amount = 10, Page = 1 });
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        VerifyMocksCalledOnce();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnAllToponyms_WhenToponymsExist()
+    {
+        // Arrange
+        var (entities, mappedDtos) = CreateValidToponymEntitiesAndDtos();
+        SetupMocksForToponyms(entities, mappedDtos);
+
+        var query = new GetAllToponymsQuery(
+            new GetAllToponymsRequestDTO { Title = null, Amount = 10, Page = 1 });
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Value.Toponyms.Should().BeEquivalentTo(mappedDtos);
+        result.Value.Pages.Should().Be(1);
+        VerifyMocksCalledOnce();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_WhenNoToponymsExist()
+    {
+        // Arrange
+        var (entities, mappedDtos) = CreateEmptyToponymEntitiesAndDtos();
+        SetupMocksForToponyms(entities, mappedDtos);
+
+        var query = new GetAllToponymsQuery(
+            new GetAllToponymsRequestDTO { Title = null, Amount = 10, Page = 1 });
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Toponyms.Should().BeEmpty();
+        VerifyMocksCalledOnce();
+    }
+
+    // ---------- helpers ----------
+
+    private static (IEnumerable<Toponym> entities, IEnumerable<ToponymDTO> dtos)
+        CreateValidToponymEntitiesAndDtos()
+    {
+        var entities = new[]
+        {
+            new Toponym { Id = 1, StreetName = "First street" },
+            new Toponym { Id = 2, StreetName = "Second street" }
+        };
+
+        var dtos = new[]
+        {
+            new ToponymDTO { Id = 1, StreetName = "First street" },
+            new ToponymDTO { Id = 2, StreetName = "Second street" }
+        };
+
+        return (entities, dtos);
+    }
+
+    private static (IEnumerable<Toponym> entities, IEnumerable<ToponymDTO> dtos)
+        CreateEmptyToponymEntitiesAndDtos() =>
+        (Array.Empty<Toponym>(), Array.Empty<ToponymDTO>());
+
+    private void SetupMocksForToponyms(
+        IEnumerable<Toponym> entities,
+        IEnumerable<ToponymDTO> mappedDtos)
+    {
+        _repositoryWrapperMock
+            .Setup(r => r.ToponymRepository.FindAll(
+                It.IsAny<Expression<Func<Toponym, bool>>>()))
+            .Returns(entities.AsQueryable());
+
+        _mapperMock
+            .Setup(m => m.Map<IEnumerable<ToponymDTO>>(It.IsAny<IEnumerable<Toponym>>()))
+            .Returns(mappedDtos);
+    }
+
+    private void VerifyMocksCalledOnce()
+    {
+        _repositoryWrapperMock.Verify(r => r.ToponymRepository.FindAll(
+            It.IsAny<Expression<Func<Toponym, bool>>>()), 
+            Times.Once);
+
+        _mapperMock.Verify(m =>
+            m.Map<IEnumerable<ToponymDTO>>(It.IsAny<IEnumerable<Toponym>>()),
+            Times.Once);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetAll/GetAllToponymsHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetAll/GetAllToponymsHandlerTests.cs
@@ -82,8 +82,6 @@ public class GetAllToponymsHandlerTests
         VerifyMocksCalledOnce();
     }
 
-    // ---------- helpers ----------
-
     private static (IEnumerable<Toponym> entities, IEnumerable<ToponymDTO> dtos)
         CreateValidToponymEntitiesAndDtos()
     {

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetById/GetToponymByIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetById/GetToponymByIdHandlerTests.cs
@@ -1,0 +1,159 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using AutoMapper;
+using Moq;
+using Xunit;
+using FluentAssertions;
+using Streetcode.BLL.DTO.Toponyms;
+using Streetcode.BLL.MediatR.Toponyms.GetById;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.DAL.Entities.Toponyms;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.XUnitTest.BLL.MediatRTests.Toponyms.GetById;
+
+public class GetToponymByIdHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<ILoggerService> _loggerMock = new();
+    private readonly GetToponymByIdHandler _handler;
+
+    public GetToponymByIdHandlerTests()
+    {
+        _handler = new GetToponymByIdHandler(
+            _repositoryMock.Object,
+            _mapperMock.Object, 
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_WhenToponymExists()
+    {
+        // Arrange
+        var (entity, mappedDto) = CreateValidToponym();
+        SetupMocksForSuccessfulQuery(entity, mappedDto);
+
+        var query = new GetToponymByIdQuery(1);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(mappedDto);
+        VerifyMocksCalledOnce();
+    }
+
+    [Fact] 
+    public async Task Handle_ShouldReturnFailResult_WhenToponymDoesNotExist()
+    {
+        // Arrange
+        SetupMocksForFailedQuery();
+        var query = new GetToponymByIdQuery(999);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        VerifyLoggingOnFailure(query);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailResult_WhenIdIsNegative() 
+    {
+        // Arrange
+        SetupMocksForFailedQuery();
+        var query = new GetToponymByIdQuery(-1);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        VerifyLoggingOnFailure(query);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailResult_WhenIdIsZero()
+    {
+        // Arrange  
+        SetupMocksForFailedQuery();
+        var query = new GetToponymByIdQuery(0);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        VerifyLoggingOnFailure(query);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldMapCorrectly_WhenToponymFound()
+    {
+        // Arrange
+        var (entity, mappedDto) = CreateValidToponym();
+        SetupMocksForSuccessfulQuery(entity, mappedDto);
+
+        var query = new GetToponymByIdQuery(1);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Value.Id.Should().Be(entity.Id);
+        result.Value.StreetName.Should().Be(entity.StreetName);
+        _mapperMock.Verify(m => m.Map<ToponymDTO>(entity), Times.Once);
+    }
+
+    private static (Toponym entity, ToponymDTO dto) CreateValidToponym()
+    {
+        var entity = new Toponym { Id = 1, StreetName = "Main" };
+        var dto = new ToponymDTO { Id = 1, StreetName = "Main" };
+        return (entity, dto);
+    }
+
+    private void SetupMocksForSuccessfulQuery(Toponym entity, ToponymDTO mappedDto)
+    {
+        _repositoryMock
+            .Setup(r => r.ToponymRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Toponym, bool>>>(),
+                It.IsAny<Func<IQueryable<Toponym>, IIncludableQueryable<Toponym, object>>>()))
+            .ReturnsAsync(entity);
+
+        _mapperMock
+            .Setup(m => m.Map<ToponymDTO>(entity))
+            .Returns(mappedDto);
+    }
+
+    private void SetupMocksForFailedQuery()
+    {
+        _repositoryMock
+            .Setup(r => r.ToponymRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Toponym, bool>>>(),  
+                It.IsAny<Func<IQueryable<Toponym>, IIncludableQueryable<Toponym, object>>>()))
+            .ReturnsAsync((Toponym?)null);
+    }
+
+    private void VerifyMocksCalledOnce()
+    {
+        _repositoryMock.Verify(
+            r => r.ToponymRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Toponym, bool>>>(),
+                It.IsAny<Func<IQueryable<Toponym>, IIncludableQueryable<Toponym, object>>>()),
+            Times.Once);
+
+        _mapperMock.Verify(
+            m => m.Map<ToponymDTO>(It.IsAny<Toponym>()),
+            Times.Once);
+    }
+
+    private void VerifyLoggingOnFailure(GetToponymByIdQuery query)
+    {
+        _loggerMock.Verify(
+            l => l.LogError(query, It.IsAny<string>()),
+            Times.Once);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandlerTests.cs
@@ -1,0 +1,152 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using AutoMapper;
+using Moq;
+using Xunit;
+using FluentAssertions;
+using Streetcode.BLL.DTO.Toponyms;
+using Streetcode.BLL.MediatR.Toponyms.GetByStreetcodeId;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.DAL.Entities.Toponyms;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.XUnitTest.BLL.MediatRTests.Toponyms.GetByStreetcodeId;
+
+public class GetToponymsByStreetcodeIdHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<ILoggerService> _loggerMock = new();
+    private readonly GetToponymsByStreetcodeIdHandler _handler;
+
+    public GetToponymsByStreetcodeIdHandlerTests()
+    {
+        _handler = new GetToponymsByStreetcodeIdHandler(
+            _repositoryMock.Object,
+            _mapperMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_WhenToponymsExist()
+    {
+        // Arrange
+        var (entities, distinctDtos) = CreateToponymsWithDuplicates();
+        SetupRepositoryReturn(entities);
+        SetupMapperReturn(distinctDtos);
+
+        var query = new GetToponymsByStreetcodeIdQuery(22);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(distinctDtos);
+        VerifyRepositoryCalledOnce();
+        _loggerMock.Verify(l => l.LogError(It.IsAny<object?>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnDistinctToponyms_WhenDuplicatesExist()
+    {
+        // Arrange
+        var (entities, distinctDtos) = CreateToponymsWithDuplicates();
+        SetupRepositoryReturn(entities);
+        SetupMapperReturn(distinctDtos);
+
+        var query  = new GetToponymsByStreetcodeIdQuery(22);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Value
+              .Select(t => t.StreetName)
+              .Should()
+              .OnlyHaveUniqueItems()
+              .And
+              .BeEquivalentTo(new[] { "Main" });
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallMapperOncePerDistinctToponym()
+    {
+        // Arrange
+        var (entities, distinctDtos) = CreateToponymsWithDuplicates();
+        SetupRepositoryReturn(entities);
+        SetupMapperReturn(distinctDtos);
+
+        var query = new GetToponymsByStreetcodeIdQuery(22);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+        _ = result.Value.ToList();
+
+        // Assert
+        _mapperMock.Verify(
+            m => m.Map<ToponymDTO>(It.IsAny<Toponym>()),
+            Times.Exactly(distinctDtos.Count()));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailResultAndLogError_WhenNoToponymsExist()
+    {
+        // Arrange
+        SetupRepositoryReturn(Array.Empty<Toponym>());
+
+        var query = new GetToponymsByStreetcodeIdQuery(22);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        _loggerMock.Verify(
+            l => l.LogError(query, $"Cannot find any toponym by the streetcode id: {query.StreetcodeId}"),
+            Times.Once);
+    }
+
+    private static (IEnumerable<Toponym> entities, IEnumerable<ToponymDTO> dtos) CreateToponymsWithDuplicates()
+    {
+        var entities = new[]
+        {
+            new Toponym { Id = 1, StreetName = "Main" },
+            new Toponym { Id = 2, StreetName = "Main" }
+        };
+
+        var dtos = new[]
+        {
+            new ToponymDTO { Id = 1, StreetName = "Main" }
+        };
+
+        return (entities, dtos);
+    }
+
+    private void SetupRepositoryReturn(IEnumerable<Toponym> entities)
+    {
+        _repositoryMock
+            .Setup(r => r.ToponymRepository.GetAllAsync(
+                It.IsAny<Expression<Func<Toponym, bool>>>(),
+                It.IsAny<Func<IQueryable<Toponym>,
+                              IIncludableQueryable<Toponym, object>>>()))
+            .ReturnsAsync(entities);
+    }
+
+    private void SetupMapperReturn(IEnumerable<ToponymDTO> dtos)
+    {
+        _mapperMock
+            .Setup(m => m.Map<ToponymDTO>(It.IsAny<Toponym>()))
+            .Returns<Toponym>(t =>
+                dtos.FirstOrDefault(d => d.Id == t.Id) ??
+                new ToponymDTO { Id = t.Id, StreetName = t.StreetName });
+    }
+
+    private void VerifyRepositoryCalledOnce()
+        => _repositoryMock.Verify(
+                r => r.ToponymRepository.GetAllAsync(
+                    It.IsAny<Expression<Func<Toponym, bool>>>(),
+                    It.IsAny<Func<IQueryable<Toponym>,
+                                  IIncludableQueryable<Toponym, object>>>()),
+                Times.Once);
+}


### PR DESCRIPTION

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Summary of issue

Unit tests were needed for the Toponym query handlers to ensure their proper functionality and to validate various scenarios including success, failure, and edge cases.

## Summary of change

Added unit tests for the GetById, GetByStreetcodeId, and GetAll MediatR Toponym query handlers. The tests cover success and failure scenarios, edge case handling, and verification of mapping and repository interactions.

## Testing approach

Unit tests were written to validate functionality and coverage for all relevant Toponym query handlers, ensuring thorough testing of multiple scenarios.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
