### PR TITLE
refactor/106: Add StreetcodeId property to FactDTO class

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Fact/FactDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Fact/FactDTO.cs
@@ -5,5 +5,6 @@ public class FactDTO
     public int Id { get; set; }
     public string Title { get; set; }
     public int ImageId { get; set; }
+    public int StreetcodeId { get; set; }
     public string FactContent { get; set; }
 }


### PR DESCRIPTION
dev

## Code reviewers

- [x] @Andriy1409 
- [x] @AndreyDot 

## Summary of issue

#106 
FactDTO needs a required StreetcodeId property; without it the mapping defaults to 0.

## Summary of change

Introduced a new `StreetcodeId` property of type `int` in the `FactDTO` class within `FactDTO.cs`. This addition will facilitate the association of facts with specific streetcodes.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
