### PR TITLE
Make Position property nullable in CreateFactHandler

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Create/CreateFactHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Create/CreateFactHandler.cs
@@ -58,6 +58,7 @@ public class CreateFactHandler : IRequestHandler<CreateFactCommand, Result<FactU
         }
 
         newFact.ImageId = newFact.ImageId == 0 ? null : newFact.ImageId;
+        newFact.Position = newFact.Position == 0 ? null : newFact.Position;
 
         var entity = await _repositoryWrapper.FactRepository.CreateAsync(newFact);
         var isSuccessResult = await _repositoryWrapper.SaveChangesAsync() > 0;


### PR DESCRIPTION
dev

## Code reviewers

- [x] @Andriy1409 

## Summary of issue

#121
Set position to null if not provided in CreateFactHandler

Update CreateFactHandler to assign null to position when it's not specified during creation. 

## Summary of change

Added logic to set newFact.Position to null if it is 0, ensuring it can be nullable like the ImageId property.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
