### PR TITLE
Rule SA1400 changed from settings.ruleset

### DIFF
--- a/Streetcode/settings.ruleset
+++ b/Streetcode/settings.ruleset
@@ -71,7 +71,6 @@
     <Rule Id="SA1311" Action="Error" />
     <Rule Id="SA1312" Action="Error" />
     <Rule Id="SA1313" Action="None" />
-    <Rule Id="SA1400" Action="Error" />
     <Rule Id="SA1402" Action="Error" />
     <Rule Id="SA1403" Action="Error" />
     <Rule Id="SA1407" Action="None" />


### PR DESCRIPTION
dev

## Code reviewers

- [x] @Tolia645 
- [x] @AndreyDot 

## Summary of issue
#138 
Change the SA1400 rule from Error to Warning

## Summary of change

From the settings.ruleset file, the rule with the identifier ‘SA1400’ was changed, for which the action was previously set to “Error” and now ‘Warning’

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
