### PR TITLE
Rename parameter 'extension' to 'mimeType' to match the interface declaration.

### DIFF
--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/BlobService.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/BlobService.cs
@@ -39,7 +39,7 @@ public class BlobService : IBlobService
         return Convert.ToBase64String(decodedBytes);
     }
 
-    public async Task<string> SaveFileInStorageAsync(string base64, string name, string extension)
+    public async Task<string> SaveFileInStorageAsync(string base64, string name, string mimeType)
     {
         byte[] imageBytes = Convert.FromBase64String(base64);
         string createdFileName = $"{DateTime.Now}{name}"
@@ -50,7 +50,7 @@ public class BlobService : IBlobService
         string hashBlobStorageName = HashFunction(createdFileName);
 
         Directory.CreateDirectory(_blobPath);
-        await EncryptFileAsync(imageBytes, extension, hashBlobStorageName);
+        await EncryptFileAsync(imageBytes, mimeType, hashBlobStorageName);
 
         return hashBlobStorageName;
     }


### PR DESCRIPTION
dev

## Code reviewers

- [x] @Yazheviika 
- [x] @ErikSavchynAI 
## Summary of issue
#155 
Rename parameter 'extension' to 'mimeType' to match the interface declaration in Streetcode/Streetcode.BLL/Services/BlobStorageService/BlobService.cs

## Summary of change

Updated the `SaveFileInStorageAsync` method to replace the `extension` parameter with a `mimeType` parameter. This change enhances file type handling and modifies the `EncryptFileAsync` call to utilize the MIME type for encryption instead of the file extension.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
