### PR TITLE
Add migration for ImageDescription field in facts table

### DIFF
--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20250605203346_AddImageDescriptionField.Designer.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20250605203346_AddImageDescriptionField.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Streetcode.DAL.Persistence;
 
@@ -11,9 +12,11 @@ using Streetcode.DAL.Persistence;
 namespace Streetcode.DAL.Persistence.Migrations
 {
     [DbContext(typeof(StreetcodeDbContext))]
-    partial class StreetcodeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250605203346_AddImageDescriptionField")]
+    partial class AddImageDescriptionField
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20250605203346_AddImageDescriptionField.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20250605203346_AddImageDescriptionField.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Streetcode.DAL.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageDescriptionField : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "StreetcodeId",
+                schema: "streetcode",
+                table: "terms",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                schema: "streetcode",
+                table: "facts",
+                type: "nvarchar(68)",
+                maxLength: 68,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ImageDescription",
+                schema: "streetcode",
+                table: "facts",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StreetcodeId",
+                schema: "streetcode",
+                table: "terms");
+
+            migrationBuilder.DropColumn(
+                name: "ImageDescription",
+                schema: "streetcode",
+                table: "facts");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                schema: "streetcode",
+                table: "facts",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(68)",
+                oldMaxLength: 68);
+        }
+    }
+}


### PR DESCRIPTION
dev

## Code reviewers

- [x] @ErikSavchynAI 
- [x] @Tolia645 

## Summary of issue

#215 
Create a migration that adds a new field `ImageDescription` to the appropriate database table.

## Summary of change

Added only the migration for adding the `ImageDescription` field.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
