### PR TITLE
feat/144/error-middleware

### DIFF
--- a/Streetcode/Streetcode.BLL/Behaviors/ValidationBehavior.cs
+++ b/Streetcode/Streetcode.BLL/Behaviors/ValidationBehavior.cs
@@ -76,6 +76,8 @@ public sealed class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<
                             && m.GetParameters().Length == 1);
 
             var genericFail = failMethod.MakeGenericMethod(payloadType);
+            /*TODO - instead of catching a ValidationException through
+            ValidationExceptionHandler, 500 is returned instead*/
             var instance = genericFail.Invoke(null, new object?[] { errors });
 
             return (TResponse)instance!;

--- a/Streetcode/Streetcode.WebApi/Middlewares/ValidationExceptionHandler.cs
+++ b/Streetcode/Streetcode.WebApi/Middlewares/ValidationExceptionHandler.cs
@@ -1,0 +1,43 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Streetcode.WebApi.Middlewares;
+
+public class ValidationExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<ValidationExceptionHandler> _logger;
+
+    public ValidationExceptionHandler
+            (ILogger<ValidationExceptionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (exception is not ValidationException validationException)
+        {
+            return false;
+        }
+
+        _logger.LogError(
+            validationException,
+            "Validation exception occurred: {Message}",
+            validationException.Message);
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Bad Request",
+            Detail = validationException.Message
+        };
+
+        httpContext.Response.StatusCode = problemDetails.Status.Value;
+
+        await httpContext.Response
+            .WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Program.cs
+++ b/Streetcode/Streetcode.WebApi/Program.cs
@@ -1,6 +1,7 @@
 using Hangfire;
 using Streetcode.BLL.Services.BlobStorageService;
 using Streetcode.WebApi.Extensions;
+using Streetcode.WebApi.Middlewares;
 using Streetcode.WebApi.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -9,10 +10,13 @@ builder.Host.ConfigureApplication();
 builder.Services.AddApplicationServices(builder.Configuration);
 builder.Services.AddSwaggerServices();
 builder.Services.AddCustomServices();
+builder.Services.AddExceptionHandler<ValidationExceptionHandler>();
+builder.Services.AddProblemDetails();
 builder.Services.ConfigureBlob(builder);
 builder.Services.ConfigurePayment(builder);
 builder.Services.ConfigureInstagram(builder);
 builder.Services.ConfigureSerilog(builder);
+
 var app = builder.Build();
 
 if (app.Environment.EnvironmentName == "Local")
@@ -35,6 +39,8 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.UseExceptionHandler();
+
 app.UseHangfireDashboard("/dash");
 
 if (app.Environment.EnvironmentName != "Local")
@@ -56,6 +62,7 @@ if (app.Environment.EnvironmentName != "Local")
 app.MapControllers();
 
 app.Run();
+
 public partial class Program
 {
 }


### PR DESCRIPTION
See Streetcode/Streetcode.BLL/Behaviors/ValidationBehavior.cs - if 
```
if (typeof(TResponse).IsGenericType
            && typeof(TResponse).GetGenericTypeDefinition() == typeof(Result<>))
```
code block is commented out, then the exception is caught and StatusCodes.Status400BadRequest is returned as planned. In other case the 500 error is returned and the exception is not caught. Either I don't really understand the principle of this code block or it doesn't work as intended
