### PR TITLE
Updated logic for unlinking related terms

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermCommand.cs
@@ -4,4 +4,4 @@ using Streetcode.BLL.DTO.Streetcode.TextContent;
 
 namespace Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Delete;
 
-public record DeleteRelatedTermCommand(string word) : IRequest<Result<RelatedTermDTO>>;
+public record DeleteRelatedTermCommand(string word, int termId) : IRequest<Result<RelatedTermDTO>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermHandler.cs
@@ -22,11 +22,11 @@ public class DeleteRelatedTermHandler : IRequestHandler<DeleteRelatedTermCommand
 
     public async Task<Result<RelatedTermDTO>> Handle(DeleteRelatedTermCommand request, CancellationToken cancellationToken)
     {
-        var relatedTerm = await _repository.RelatedTermRepository.GetFirstOrDefaultAsync(rt => rt.Word.ToLower().Equals(request.word.ToLower()));
+        var relatedTerm = await _repository.RelatedTermRepository.GetFirstOrDefaultAsync(rt => rt.Word.ToLower().Equals(request.word.ToLower()) && rt.TermId == request.termId);
 
         if (relatedTerm is null)
         {
-            string errorMsg = $"Cannot find a related term: {request.word}";
+            string errorMsg = $"Cannot find a related term: {request.word} for term ID {request.termId}";
             _logger.LogError(request, errorMsg);
             return Result.Fail(new Error(errorMsg));
         }

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
@@ -27,9 +27,9 @@ public class RelatedTermController : BaseApiController
         return HandleResult(await Mediator.Send(new UpdateRelatedTermCommand(id, relatedTerm)));
     }
 
-    [HttpDelete("{word}")]
-    public async Task<IActionResult> Delete([FromRoute] string word)
+    [HttpDelete("{word}/{termId:int}")]
+    public async Task<IActionResult> Delete([FromRoute] string word, [FromRoute] int termId)
     {
-        return HandleResult(await Mediator.Send(new DeleteRelatedTermCommand(word)));
+        return HandleResult(await Mediator.Send(new DeleteRelatedTermCommand(word, termId)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Streetcode/RelatedTermTests/Delete/DeleteRelatedTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatRTests/Streetcode/RelatedTermTests/Delete/DeleteRelatedTermHandlerTests.cs
@@ -30,9 +30,9 @@ public class DeleteRelatedTermHandlerTests
         _mockRepositoryWrapper.Setup(x => x.RelatedTermRepository).Returns(_mockRelatedTermRepository.Object);
     }
 
-    private async Task<Result<RelatedTermDTO>> ArrangeAndActAsync(string wordToFind, RelatedTerm foundEntity = null, int saveChangesResult = 1, RelatedTermDTO mappedDtoResult = null)
+    private async Task<Result<RelatedTermDTO>> ArrangeAndActAsync(string wordToFind, int termId, RelatedTerm foundEntity = null, int saveChangesResult = 1, RelatedTermDTO mappedDtoResult = null)
     {
-        var command = new DeleteRelatedTermCommand(wordToFind);
+        var command = new DeleteRelatedTermCommand(wordToFind, termId);
 
         _mockRelatedTermRepository.Setup(repo => repo.GetFirstOrDefaultAsync(
             It.IsAny<Expression<System.Func<RelatedTerm, bool>>>(),
@@ -64,7 +64,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        var result = await ArrangeAndActAsync(existingWord, foundEntity, 1, mappedDto);
+        var result = await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, mappedDto);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -79,7 +79,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        var result = await ArrangeAndActAsync(existingWord, foundEntity, 1, mappedDto);
+        var result = await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, mappedDto);
 
         // Assert
         result.Value.Should().BeEquivalentTo(mappedDto);
@@ -94,7 +94,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, mappedDto);
 
         // Assert
         _mockRelatedTermRepository.Verify(
@@ -111,7 +111,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, mappedDto);
 
         // Assert
         _mockRelatedTermRepository.Verify(repo => repo.Delete(foundEntity), Times.Once);
@@ -126,7 +126,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, mappedDto);
 
         // Assert
         _mockRepositoryWrapper.Verify(repo => repo.SaveChangesAsync(), Times.Once);
@@ -141,7 +141,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, mappedDto);
 
         // Assert
         _mockMapper.Verify(m => m.Map<RelatedTermDTO>(foundEntity), Times.Once);
@@ -156,7 +156,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, mappedDto);
 
         // Assert
         _mockLogger.Verify(logger => logger.LogError(It.IsAny<DeleteRelatedTermCommand>(), It.IsAny<string>()), Times.Never);
@@ -168,9 +168,10 @@ public class DeleteRelatedTermHandlerTests
     {
         // Arrange
         var wordToFind = "NonExistingWord";
+        var termId = 0;
 
         // Act
-        var result = await ArrangeAndActAsync(wordToFind, null);
+        var result = await ArrangeAndActAsync(wordToFind, termId, null);
 
         // Assert
         result.IsFailed.Should().BeTrue();
@@ -181,10 +182,11 @@ public class DeleteRelatedTermHandlerTests
     {
         // Arrange
         var wordToFind = "NonExistingWord";
-        var expectedErrorMessage = $"Cannot find a related term: {wordToFind}";
+        var termId = 0;
+        var expectedErrorMessage = $"Cannot find a related term: {wordToFind} for term ID {termId}";
 
         // Act
-        var result = await ArrangeAndActAsync(wordToFind, null);
+        var result = await ArrangeAndActAsync(wordToFind, termId, null);
 
         // Assert
         result.Errors.Should().ContainSingle(e => e.Message == expectedErrorMessage);
@@ -195,9 +197,10 @@ public class DeleteRelatedTermHandlerTests
     {
         // Arrange
         var wordToFind = "NonExistingWord";
+        var termId = 0;
 
         // Act
-        await ArrangeAndActAsync(wordToFind, null);
+        await ArrangeAndActAsync(wordToFind, termId, null);
 
         // Assert
         _mockRelatedTermRepository.Verify(
@@ -210,9 +213,10 @@ public class DeleteRelatedTermHandlerTests
     {
         // Arrange
         var wordToFind = "NonExistingWord";
+        var termId = 0;
 
         // Act
-        await ArrangeAndActAsync(wordToFind, null);
+        await ArrangeAndActAsync(wordToFind, termId, null);
 
         // Assert
         _mockRelatedTermRepository.Verify(repo => repo.Delete(It.IsAny<RelatedTerm>()), Times.Never);
@@ -223,9 +227,10 @@ public class DeleteRelatedTermHandlerTests
     {
         // Arrange
         var wordToFind = "NonExistingWord";
+        var termId = 0;
 
         // Act
-        await ArrangeAndActAsync(wordToFind, null);
+        await ArrangeAndActAsync(wordToFind, termId, null);
 
         // Assert
         _mockRepositoryWrapper.Verify(repo => repo.SaveChangesAsync(), Times.Never);
@@ -236,9 +241,10 @@ public class DeleteRelatedTermHandlerTests
     {
         // Arrange
         var wordToFind = "NonExistingWord";
+        var termId = 0;
 
         // Act
-        await ArrangeAndActAsync(wordToFind, null);
+        await ArrangeAndActAsync(wordToFind, termId, null);
 
         // Assert
         _mockMapper.Verify(m => m.Map<RelatedTermDTO>(It.IsAny<RelatedTerm>()), Times.Never);
@@ -249,17 +255,17 @@ public class DeleteRelatedTermHandlerTests
     {
         // Arrange
         var wordToFind = "NonExistingWord";
-        var expectedErrorMessage = $"Cannot find a related term: {wordToFind}";
+        var termId = 0;
+        var expectedErrorMessage = $"Cannot find a related term: {wordToFind} for term ID {termId}";
 
         // Act
-        await ArrangeAndActAsync(wordToFind, null);
+        await ArrangeAndActAsync(wordToFind, termId, null);
 
         // Assert
         _mockLogger.Verify(
             logger => logger.LogError(It.IsAny<DeleteRelatedTermCommand>(), expectedErrorMessage),
             Times.Once);
     }
-
 
     [Fact]
     public async Task Handle_SaveChangesAsyncReturnsZero_ShouldReturnFailureResult()
@@ -270,7 +276,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        var result = await ArrangeAndActAsync(existingWord, foundEntity, 0, mappedDto);
+        var result = await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 0, mappedDto);
 
         // Assert
         result.IsFailed.Should().BeTrue();
@@ -286,7 +292,7 @@ public class DeleteRelatedTermHandlerTests
         var expectedErrorMessage = "Failed to delete a related term";
 
         // Act
-        var result = await ArrangeAndActAsync(existingWord, foundEntity, 0, mappedDto);
+        var result = await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 0, mappedDto);
 
         // Assert
         result.Errors.Should().ContainSingle(e => e.Message == expectedErrorMessage);
@@ -301,7 +307,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 0, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 0, mappedDto);
 
         // Assert
         _mockRelatedTermRepository.Verify(
@@ -318,7 +324,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 0, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 0, mappedDto);
 
         // Assert
         _mockRelatedTermRepository.Verify(repo => repo.Delete(foundEntity), Times.Once);
@@ -333,7 +339,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 0, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 0, mappedDto);
 
         // Assert
         _mockRepositoryWrapper.Verify(repo => repo.SaveChangesAsync(), Times.Once);
@@ -348,7 +354,7 @@ public class DeleteRelatedTermHandlerTests
         var mappedDto = new RelatedTermDTO { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 0, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 0, mappedDto);
 
         // Assert
         _mockMapper.Verify(m => m.Map<RelatedTermDTO>(foundEntity), Times.Once);
@@ -364,7 +370,7 @@ public class DeleteRelatedTermHandlerTests
         var expectedErrorMessage = "Failed to delete a related term";
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 0, mappedDto);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 0, mappedDto);
 
         // Assert
         _mockLogger.Verify(
@@ -381,7 +387,7 @@ public class DeleteRelatedTermHandlerTests
         var foundEntity = new RelatedTerm { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        var result = await ArrangeAndActAsync(existingWord, foundEntity, 1, null); // mappedDtoResult is null
+        var result = await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, null); // mappedDtoResult is null
 
         // Assert
         result.IsFailed.Should().BeTrue();
@@ -396,7 +402,7 @@ public class DeleteRelatedTermHandlerTests
         var expectedErrorMessage = "Failed to delete a related term";
 
         // Act
-        var result = await ArrangeAndActAsync(existingWord, foundEntity, 1, null); // mappedDtoResult is null
+        var result = await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, null); // mappedDtoResult is null
 
         // Assert
         result.Errors.Should().ContainSingle(e => e.Message == expectedErrorMessage);
@@ -410,7 +416,7 @@ public class DeleteRelatedTermHandlerTests
         var foundEntity = new RelatedTerm { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, null);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, null);
 
         // Assert
         _mockRelatedTermRepository.Verify(
@@ -426,7 +432,7 @@ public class DeleteRelatedTermHandlerTests
         var foundEntity = new RelatedTerm { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, null);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, null);
 
         // Assert
         _mockRelatedTermRepository.Verify(repo => repo.Delete(foundEntity), Times.Once);
@@ -440,7 +446,7 @@ public class DeleteRelatedTermHandlerTests
         var foundEntity = new RelatedTerm { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, null);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, null);
 
         // Assert
         _mockRepositoryWrapper.Verify(repo => repo.SaveChangesAsync(), Times.Once);
@@ -454,7 +460,7 @@ public class DeleteRelatedTermHandlerTests
         var foundEntity = new RelatedTerm { Id = 1, Word = existingWord, TermId = 1 };
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, null);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, null);
 
         // Assert
         _mockMapper.Verify(m => m.Map<RelatedTermDTO>(foundEntity), Times.Once);
@@ -469,7 +475,7 @@ public class DeleteRelatedTermHandlerTests
         var expectedErrorMessage = "Failed to delete a related term";
 
         // Act
-        await ArrangeAndActAsync(existingWord, foundEntity, 1, null);
+        await ArrangeAndActAsync(existingWord, foundEntity.TermId, foundEntity, 1, null);
 
         // Assert
         _mockLogger.Verify(


### PR DESCRIPTION
## Summary of issue

Deleting a related term did not take into account its association with a specific term, which might result in deleting the wrong synonym.

## Summary of change

Changed logic for handler, controller, command to consider original term id. Rewritten tests for new logic.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=80%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
