### PR TITLE
added namespace line to ResultValueOnlyConverter class

### DIFF
--- a/Streetcode/Streetcode.BLL/Behaviors/CacheBehavior/ResultValueOnlyConverter.cs
+++ b/Streetcode/Streetcode.BLL/Behaviors/CacheBehavior/ResultValueOnlyConverter.cs
@@ -1,6 +1,8 @@
 using FluentResults;
 using Newtonsoft.Json;
 
+namespace Streetcode.BLL.Behaviors;
+
 public class ResultValueOnlyConverter<T> : JsonConverter<Result<T>>
 {
     public override void WriteJson(JsonWriter writer, Result<T> result, JsonSerializer serializer)

--- a/Streetcode/Streetcode.DAL/Entities/Sources/StreetcodeCategoryContent.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Sources/StreetcodeCategoryContent.cs
@@ -23,5 +23,4 @@ public class StreetcodeCategoryContent
 
     public SourceLinkCategory? SourceLinkCategory { get; set; }
     public StreetcodeContent? Streetcode { get; set; }
-    public int Id { get; set; }
 }

--- a/Streetcode/Streetcode.sln
+++ b/Streetcode/Streetcode.sln
@@ -26,7 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UserService", "UserService"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UserService.WebApi", "UserService.WebApi\UserService.WebApi.csproj", "{226FD87C-C659-4F19-9D6F-B104737E877D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserService.XUnitTest", "UserService\UserService.XUnitTest\UserService.XUnitTest.csproj", "{0B372C24-CA2F-4A63-BCDA-E50EF8DB5822}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UserService.XUnitTest", "UserService\UserService.XUnitTest\UserService.XUnitTest.csproj", "{0B372C24-CA2F-4A63-BCDA-E50EF8DB5822}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ApiGateway", "ApiGateway", "{6053A963-15D0-49FB-B4CF-8EC7ABD507EA}"
 EndProject
@@ -68,14 +68,21 @@ Global
 		{226FD87C-C659-4F19-9D6F-B104737E877D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{226FD87C-C659-4F19-9D6F-B104737E877D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{226FD87C-C659-4F19-9D6F-B104737E877D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B372C24-CA2F-4A63-BCDA-E50EF8DB5822}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B372C24-CA2F-4A63-BCDA-E50EF8DB5822}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B372C24-CA2F-4A63-BCDA-E50EF8DB5822}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B372C24-CA2F-4A63-BCDA-E50EF8DB5822}.Release|Any CPU.Build.0 = Release|Any CPU
 		{463724F7-8AD6-4B2C-8CEA-FA27C9442C60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{463724F7-8AD6-4B2C-8CEA-FA27C9442C60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463724F7-8AD6-4B2C-8CEA-FA27C9442C60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463724F7-8AD6-4B2C-8CEA-FA27C9442C60}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{226FD87C-C659-4F19-9D6F-B104737E877D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{0B372C24-CA2F-4A63-BCDA-E50EF8DB5822} = {00000000-0000-0000-0000-000000000000}
 		{463724F7-8AD6-4B2C-8CEA-FA27C9442C60} = {6053A963-15D0-49FB-B4CF-8EC7ABD507EA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution


### PR DESCRIPTION
## Fixed noncompliant code for ResultValueOnlyConverter class without named namespace. The file name also has been changed to match the public class name to facilitate project navigation, code readability, and predictability.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
