### PR TITLE
added namespace line to ResultValueOnlyConverter class 

### DIFF
--- a/Streetcode/Streetcode.BLL/Behaviors/CacheBehavior/ResultValueOnlyConverter.cs
+++ b/Streetcode/Streetcode.BLL/Behaviors/CacheBehavior/ResultValueOnlyConverter.cs
@@ -1,6 +1,8 @@
 using FluentResults;
 using Newtonsoft.Json;
 
+namespace Streetcode.BLL.Behaviors;
+
 public class ResultValueOnlyConverter<T> : JsonConverter<Result<T>>
 {
     public override void WriteJson(JsonWriter writer, Result<T> result, JsonSerializer serializer)


### PR DESCRIPTION
## Fixed noncompliant code for ResultValueOnlyConverter class without named namespace. The file name also has been changed to match the public class name to facilitate project navigation, code readability, and predictability.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
