### PR TITLE
used a comparison to 'default(T)' instead of comparison to null

### DIFF
--- a/Streetcode/UserService.WebApi/Controllers/BaseApiController.cs
+++ b/Streetcode/UserService.WebApi/Controllers/BaseApiController.cs
@@ -10,7 +10,7 @@ public class BaseApiController : ControllerBase
     {
         if (result.IsSuccess)
         {
-            return result.Value == null
+            return EqualityComparer<T>.Default.Equals(result.Value, default)
                 ? NotFound()
                 : Ok(result.Value);
         }


### PR DESCRIPTION
## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
