### PR TITLE
Сreate background job(Quartz) to delete revoked refresh tokens

### DIFF
--- a/Streetcode/UserService.WebApi/Data/Repositories/Interfaces/IRefreshTokenRepository.cs
+++ b/Streetcode/UserService.WebApi/Data/Repositories/Interfaces/IRefreshTokenRepository.cs
@@ -11,4 +11,6 @@ public interface IRefreshTokenRepository
     Task UpdateAsync(RefreshToken refreshToken, CancellationToken cancellationToken);
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+
+    Task<int> BulkDeleteRevokedTokensAsync(CancellationToken cancellationToken = default);
 }

--- a/Streetcode/UserService.WebApi/Data/Repositories/Realisations/RefreshTokenRepository.cs
+++ b/Streetcode/UserService.WebApi/Data/Repositories/Realisations/RefreshTokenRepository.cs
@@ -36,4 +36,11 @@ public class RefreshTokenRepository : IRefreshTokenRepository
     {
         return await _dbContext.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task<int> BulkDeleteRevokedTokensAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.RefreshTokens
+            .Where(rt => rt.IsRevoked)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
 }

--- a/Streetcode/UserService.WebApi/Extensions/QuartzExtensions.cs
+++ b/Streetcode/UserService.WebApi/Extensions/QuartzExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Quartz;
+using UserService.WebApi.Jobs.Configurations;
+
+namespace UserService.WebApi.Extensions;
+
+public static class QuartzExtensions
+{
+    public static IServiceCollection AddQuartzJobs(this IServiceCollection services)
+    {
+        services.AddQuartz();
+
+        services.AddQuartzHostedService(options =>
+        {
+            options.WaitForJobsToComplete = true;
+        });
+
+        services.ConfigureOptions<DeleteRevokedRefreshTokensJobConfiguration>();
+
+        return services;
+    }
+}

--- a/Streetcode/UserService.WebApi/Jobs/Configurations/DeleteRevokedRefreshTokensJobConfiguration.cs
+++ b/Streetcode/UserService.WebApi/Jobs/Configurations/DeleteRevokedRefreshTokensJobConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Options;
+using Quartz;
+
+namespace UserService.WebApi.Jobs.Configurations;
+
+public class DeleteRevokedRefreshTokensJobConfiguration : IConfigureOptions<QuartzOptions>
+{
+    public void Configure(QuartzOptions options)
+    {
+        var jobKey = JobKey.Create(nameof(DeleteRevokedRefreshTokensJob));
+        options
+            .AddJob<DeleteRevokedRefreshTokensJob>(jobBuilder => jobBuilder.WithIdentity(jobKey))
+            .AddTrigger(trigger =>
+                trigger
+                    .ForJob(jobKey)
+                    .WithSimpleSchedule(schedule =>
+                        schedule
+                            .WithInterval(TimeSpan.FromDays(7.00))
+                            .RepeatForever())
+            );
+    }
+}

--- a/Streetcode/UserService.WebApi/Jobs/DeleteRevokedRefreshTokensJob.cs
+++ b/Streetcode/UserService.WebApi/Jobs/DeleteRevokedRefreshTokensJob.cs
@@ -1,0 +1,37 @@
+﻿using Quartz;
+using UserService.WebApi.Services.Interfaces;
+
+namespace UserService.WebApi.Jobs;
+
+[DisallowConcurrentExecution]
+public class DeleteRevokedRefreshTokensJob : IJob
+{
+    private readonly ITokenService _tokenService;
+    private readonly ILogger<DeleteRevokedRefreshTokensJob> _logger;
+
+    public DeleteRevokedRefreshTokensJob(
+        ITokenService tokenService,
+        ILogger<DeleteRevokedRefreshTokensJob> logger)
+    {
+        _tokenService = tokenService;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var jobName = context.JobDetail.Key.Name;
+        _logger.LogInformation($"Quartz job '{jobName}' starting at {DateTime.UtcNow}");
+
+        var result = await _tokenService.DeleteRevokedRefreshTokensAsync(context.CancellationToken);
+
+        if (result.IsSuccess)
+        {
+            _logger.LogInformation($"Quartz job '{jobName}' deleted {result.Value} revoked tokens at {DateTime.UtcNow}");
+        }
+        else
+        {
+            var errors = string.Join("; ", result.Errors);
+            _logger.LogError($"Quartz job '{jobName}' found errors but will complete gracefully: {errors}");
+        }
+    }
+}

--- a/Streetcode/UserService.WebApi/Program.cs
+++ b/Streetcode/UserService.WebApi/Program.cs
@@ -28,6 +28,8 @@ builder.Services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<ITokenService, TokenService>();
 
+builder.Services.AddQuartzJobs();
+
 builder.Services.AddValidatorsFromAssemblyContaining<LoginRequestDTOValidator>();
 
 builder.Services.AddAutoMapper(typeof(UserProfile));

--- a/Streetcode/UserService.WebApi/Services/Interfaces/ITokenService.cs
+++ b/Streetcode/UserService.WebApi/Services/Interfaces/ITokenService.cs
@@ -11,4 +11,6 @@ public interface ITokenService
     Task<Result<TokenResponseDTO>> RefreshAccessTokenAsync(string refreshToken, CancellationToken cancellationToken);
 
     Task<Result<bool>> RevokeRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken);
+
+    Task<Result<int>> DeleteRevokedRefreshTokensAsync(CancellationToken cancellationToken);
 }

--- a/Streetcode/UserService.WebApi/Services/Realisations/TokenService.cs
+++ b/Streetcode/UserService.WebApi/Services/Realisations/TokenService.cs
@@ -20,15 +20,18 @@ public class TokenService : ITokenService
     private readonly JwtSettings _jwtSettings;
     private readonly IRefreshTokenRepository _refreshTokenRepository;
     private readonly UserManager<User> _userManager;
+    private readonly ILogger<TokenService> _logger;
 
     public TokenService(
         IOptions<JwtSettings> jwtOptions,
         IRefreshTokenRepository refreshTokenRepository,
-        UserManager<User> userManager)
+        UserManager<User> userManager,
+        ILogger<TokenService> logger)
     {
         _jwtSettings = jwtOptions.Value;
         _refreshTokenRepository = refreshTokenRepository;
         _userManager = userManager;
+        _logger = logger;
     }
 
     public async Task<Result<TokenResponseDTO>> GenerateTokensAsync(User user, CancellationToken cancellationToken)
@@ -150,6 +153,26 @@ public class TokenService : ITokenService
         {
             return Result.Fail<bool>("Failed to save revoke RefreshToken.");
         }
+    }
+
+    public async Task<Result<int>> DeleteRevokedRefreshTokensAsync(
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation($"Starting bulk delete of revoked refresh tokens at {DateTime.UtcNow}");
+
+        var deletedCount = await _refreshTokenRepository
+            .BulkDeleteRevokedTokensAsync(cancellationToken);
+
+        if (deletedCount == 0)
+        {
+            _logger.LogInformation("No revoked refresh tokens found to delete.");
+        }
+        else
+        {
+            _logger.LogInformation($"Completed bulk delete of revoked refresh tokens. Total deleted: {deletedCount}");
+        }
+
+        return Result.Ok(deletedCount);
     }
 
     private string CreateJwtAccessToken(User user, IEnumerable<string> userRoles, DateTime expiresAt)

--- a/Streetcode/UserService.WebApi/UserService.WebApi.csproj
+++ b/Streetcode/UserService.WebApi/UserService.WebApi.csproj
@@ -23,6 +23,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Quartz" Version="3.14.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
dev

## Code reviewers

- [x] @AndreyDot 
- [x] @Tolia645 

## Summary of issue

#278 
The task was to create a backend job with Quartz to delete revoked tokens.

## Summary of change

I have created a Quartz job backend that removes revoked tokens. I created extension methods and a configuration for the job.

## Testing approach

![image](https://github.com/user-attachments/assets/82589fd5-15e0-49c7-8701-9d501504daee)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
