### PR TITLE
Rename parameter in AddAsync method for clarity

### DIFF
--- a/Streetcode/UserService.WebApi/Data/Repositories/Realisations/UsersRepository.cs
+++ b/Streetcode/UserService.WebApi/Data/Repositories/Realisations/UsersRepository.cs
@@ -11,10 +11,11 @@ public class UsersRepository : IUsersRepository
     {
         _context = context;
     }
-    public async Task<User> AddAsync(User user, CancellationToken cancellationToken)
+
+    public async Task<User> AddAsync(User newUser, CancellationToken cancellationToken)
     {
-        await _context.Users.AddAsync(user, cancellationToken);
-        return user;
+        await _context.Users.AddAsync(newUser, cancellationToken);
+        return newUser;
     }
 
     public async Task<int> SaveChangesAsync()


### PR DESCRIPTION
dev

## Code reviewers

- [x] @AndreyDot 
- [x] @Tolia645 

## Summary of issue

#261

## Summary of change

Updated the `AddAsync` method in the `UsersRepository` class to change the parameter name from `user` to `newUser`. The return statement was also modified to return `newUser`, ensuring consistency. The logic for adding the user to the context remains unchanged.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
