### PR TITLE
added realisation of password reset

### DIFF
--- a/Streetcode/UserService.WebApi/Controllers/Users/UsersController.cs
+++ b/Streetcode/UserService.WebApi/Controllers/Users/UsersController.cs
@@ -71,7 +71,7 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordDto request)
     {
         var result = await _authService.ResetPassword(request);
-
+    }
     [HttpPost("change-password")]
     [Authorize]
     public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequestDTO request, CancellationToken cancellationToken)

--- a/Streetcode/UserService.WebApi/Controllers/Users/UsersController.cs
+++ b/Streetcode/UserService.WebApi/Controllers/Users/UsersController.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
+using System.Threading;
 using UserService.WebApi.DTO.Auth.Requests;
 using UserService.WebApi.DTO.Users;
 using UserService.WebApi.Services.Interfaces;
@@ -59,6 +60,22 @@ public class UsersController : BaseApiController
         CancellationToken cancellationToken)
     {
         var result = await _authService.RefreshTokenAsync(request, cancellationToken);
+
+        return HandleResult(result);
+    }
+
+    [HttpPost("forgot-password")]
+    public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDto request)
+    {
+        var result = await _authService.ForgotPassword(request);
+
+        return HandleResult(result);
+    }
+
+    [HttpPost("reset-password")]
+    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordDto request)
+    {
+        var result = await _authService.ResetPassword(request);
 
         return HandleResult(result);
     }

--- a/Streetcode/UserService.WebApi/Controllers/Users/UsersController.cs
+++ b/Streetcode/UserService.WebApi/Controllers/Users/UsersController.cs
@@ -71,6 +71,8 @@ public class UsersController : BaseApiController
     public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordDto request)
     {
         var result = await _authService.ResetPassword(request);
+
+        return HandleResult(result);
     }
     [HttpPost("change-password")]
     [Authorize]

--- a/Streetcode/UserService.WebApi/DTO/Auth/Requests/ForgotPasswordDto.cs
+++ b/Streetcode/UserService.WebApi/DTO/Auth/Requests/ForgotPasswordDto.cs
@@ -1,0 +1,6 @@
+﻿namespace UserService.WebApi.DTO.Auth.Requests;
+
+public class ForgotPasswordDto
+{
+    public string Email { get; set; }
+}

--- a/Streetcode/UserService.WebApi/DTO/Auth/Requests/ResetPasswordDto.cs
+++ b/Streetcode/UserService.WebApi/DTO/Auth/Requests/ResetPasswordDto.cs
@@ -1,0 +1,8 @@
+﻿namespace UserService.WebApi.DTO.Auth.Requests;
+
+public class ResetPasswordDto
+{
+    public string Email { get; set; }
+    public string Token { get; set; }
+    public string NewPassword { get; set; }
+}

--- a/Streetcode/UserService.WebApi/Program.cs
+++ b/Streetcode/UserService.WebApi/Program.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.EntityFrameworkCore;
 using UserService.WebApi.Data;
 using UserService.WebApi.Data.Repositories.Interfaces;
@@ -27,6 +28,8 @@ builder.Services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
 
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<ITokenService, TokenService>();
+
+builder.Services.AddScoped<IEmailSender, EmailSender>();
 
 builder.Services.AddHangfireServerWithSqlStorage(builder.Configuration);
 builder.Services.AddQuartzJobs();

--- a/Streetcode/UserService.WebApi/Services/Interfaces/IAuthService.cs
+++ b/Streetcode/UserService.WebApi/Services/Interfaces/IAuthService.cs
@@ -14,5 +14,9 @@ public interface IAuthService
     Task<Result<TokenResponseDTO>> RefreshTokenAsync(RefreshTokenRequestDTO request, CancellationToken cancellationToken);
 
     Task<Result> LogoutAsync(LogoutRequestDTO request, CancellationToken cancellationToken);
+
+    Task<Result> ForgotPassword(ForgotPasswordDto request);
+
+    Task<Result> ResetPassword(ResetPasswordDto request);
 }
 

--- a/Streetcode/UserService.WebApi/Services/Realisations/AuthService.cs
+++ b/Streetcode/UserService.WebApi/Services/Realisations/AuthService.cs
@@ -223,6 +223,9 @@ public class AuthService : IAuthService
         if (!result.Succeeded)
         {
             return Result.Fail("Something went wrong");
+        }
+        return Result.Ok();
+    }
 
     public async Task<Result> ChangePasswordAsync(string userEmail, string oldPassword, string newPassword, CancellationToken cancellationToken)
     {

--- a/Streetcode/UserService.WebApi/Services/Realisations/AuthService.cs
+++ b/Streetcode/UserService.WebApi/Services/Realisations/AuthService.cs
@@ -2,6 +2,7 @@
 using FluentResults;
 using FluentValidation;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
 using System.IdentityModel.Tokens.Jwt;
 using UserService.WebApi.DTO.Auth.Requests;
 using UserService.WebApi.DTO.Auth.Responses;
@@ -19,8 +20,9 @@ public class AuthService : IAuthService
     private readonly UserManager<User> _userManager;
     private readonly ITokenService _tokenService;
     private readonly IValidator<LoginRequestDTO> _loginValidator;
-
     private readonly IUserRegistrationPublisher _registrationPublisher;
+    private readonly IEmailSender _emailSender;
+    private readonly IConfiguration _configuration;
 
     public AuthService(
         IMapper mapper,
@@ -28,7 +30,9 @@ public class AuthService : IAuthService
         UserManager<User> userManager,
         ITokenService tokenService,
         IValidator<LoginRequestDTO> loginValidator,
-        IUserRegistrationPublisher registrationPublisher)
+        IUserRegistrationPublisher registrationPublisher,
+        IEmailSender emailSender,
+        IConfiguration configuration)
     {
         _mapper = mapper;
         _logger = logger;
@@ -36,6 +40,8 @@ public class AuthService : IAuthService
         _tokenService = tokenService;
         _loginValidator = loginValidator;
         _registrationPublisher = registrationPublisher;
+        _emailSender = emailSender;
+        _configuration = configuration;
     }
 
     public async Task<Result<User>> Register(RegisterUserDTO registerUserDTO, CancellationToken cancellationToken)
@@ -179,6 +185,35 @@ public class AuthService : IAuthService
         }
 
         _logger.LogInformation("User logged out successfully.");
+
+        return Result.Ok();
+    }
+
+    public async Task<Result> ForgotPassword(ForgotPasswordDto request)
+    {
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user == null)
+            Result.Ok();
+
+        var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+        var callbackUrl = $"{_configuration["FrontendBaseUrl"]}/reset-password?token={Uri.EscapeDataString(token)}&email={request.Email}";
+
+        await _emailSender.SendEmailAsync(user.Email, "Password reset", $"<p>Reset: <a href='{callbackUrl}'>here</a></p>");
+
+        return Result.Ok();
+    }
+
+    public async Task<Result> ResetPassword(ResetPasswordDto request)
+    {
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user == null)
+            return Result.Fail("User not found");
+
+        var result = await _userManager.ResetPasswordAsync(user, request.Token, request.NewPassword);
+        if (!result.Succeeded)
+        {
+            return Result.Fail("Something went wrong");
+        }
 
         return Result.Ok();
     }

--- a/Streetcode/UserService.WebApi/Services/Realisations/EmailSender .cs
+++ b/Streetcode/UserService.WebApi/Services/Realisations/EmailSender .cs
@@ -1,0 +1,39 @@
+﻿using System.Net.Mail;
+using System.Net;
+using Microsoft.AspNetCore.Identity.UI.Services;
+
+namespace UserService.WebApi.Services.Realisations;
+
+public class EmailSender : IEmailSender
+{
+    private readonly IConfiguration _config;
+
+    public EmailSender(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public async Task SendEmailAsync(string email, string subject, string htmlMessage)
+    {
+        var settings = _config.GetSection("EmailSettings");
+
+        var smtpClient = new SmtpClient(settings["SmtpServer"])
+        {
+            Port = int.Parse(settings["SmtpPort"]),
+            Credentials = new NetworkCredential(settings["SenderEmail"], settings["SenderPassword"]),
+            EnableSsl = true
+        };
+
+        var message = new MailMessage
+        {
+            From = new MailAddress(settings["SenderEmail"], settings["SenderName"]),
+            Subject = subject,
+            Body = htmlMessage,
+            IsBodyHtml = true
+        };
+
+        message.To.Add(email);
+
+        await smtpClient.SendMailAsync(message);
+    }
+}

--- a/Streetcode/UserService/UserService.XUnitTest/ServicesTests/Realisations/AuthServiceTests.cs
+++ b/Streetcode/UserService/UserService.XUnitTest/ServicesTests/Realisations/AuthServiceTests.cs
@@ -4,9 +4,10 @@ using FluentResults;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Newtonsoft.Json.Linq;
 using UserService.WebApi.DTO.Auth.Requests;
 using UserService.WebApi.DTO.Auth.Responses;
 using UserService.WebApi.DTO.Users;
@@ -31,6 +32,8 @@ public class AuthServiceTests
     private readonly Mock<ITokenService> _tokenServiceMock = new();
     private readonly Mock<IValidator<LoginRequestDTO>> _validator = new();
     private readonly Mock<IUserRegistrationPublisher> _registrationPublisherMock;
+    private readonly Mock<IEmailSender> _emailSender;
+    private readonly Mock<IConfiguration> _configuration;
 
     public AuthServiceTests()
     {
@@ -42,6 +45,9 @@ public class AuthServiceTests
             userStoreMock.Object, null, null, null, null, null, null, null, null
         );
         _registrationPublisherMock = new Mock<IUserRegistrationPublisher>();
+        _emailSender = new Mock<IEmailSender>();
+        _configuration = new Mock<IConfiguration>();
+
 
         _authService = new AuthService(
             _mapperMock.Object,
@@ -49,7 +55,9 @@ public class AuthServiceTests
             _userManagerMock.Object,
             _tokenServiceMock.Object,
             _validator.Object,
-            _registrationPublisherMock.Object);
+            _registrationPublisherMock.Object,
+            _emailSender.Object,
+            _configuration.Object);
     }
 
     [Fact]

--- a/Streetcode/UserService/UserService.XUnitTest/ServicesTests/Realisations/AuthServiceTests.cs
+++ b/Streetcode/UserService/UserService.XUnitTest/ServicesTests/Realisations/AuthServiceTests.cs
@@ -279,6 +279,86 @@ public class AuthServiceTests
         result.Value.Should().BeEquivalentTo(tokenResponse);
     }
 
+    [Fact]
+    public async Task ForgotPassword_UserExists_SendsEmailAndReturnsSuccess()
+    {
+        // Arrange
+        var request = new ForgotPasswordDto { Email = "user@example.com" };
+        var user = new User { Email = request.Email };
+        var fakeToken = "test-token";
+
+        _userManagerMock.Setup(um => um.FindByEmailAsync(request.Email))
+            .ReturnsAsync(user);
+
+        _userManagerMock.Setup(um => um.GeneratePasswordResetTokenAsync(user))
+            .ReturnsAsync(fakeToken);
+
+        _configuration.Setup(c => c["FrontendBaseUrl"])
+            .Returns("http://localhost:5002");
+
+        // Act
+        var result = await _authService.ForgotPassword(request);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _emailSender.Verify(e => e.SendEmailAsync(
+            user.Email,
+            It.Is<string>(s => s.Contains("Password reset")),
+            It.Is<string>(html => html.Contains("http://localhost:5002/reset-password?token="))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ValidToken_ResetsPasswordAndReturnsSuccess()
+    {
+        // Arrange
+        var request = new ResetPasswordDto
+        {
+            Email = "user@example.com",
+            Token = "valid-token",
+            NewPassword = "NewPassword123!"
+        };
+
+        var user = new User { Email = request.Email };
+
+        _userManagerMock.Setup(um => um.FindByEmailAsync(request.Email))
+            .ReturnsAsync(user);
+
+        _userManagerMock.Setup(um => um.ResetPasswordAsync(user, request.Token, request.NewPassword))
+            .ReturnsAsync(IdentityResult.Success);
+
+        // Act
+        var result = await _authService.ResetPassword(request);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+
+    [Fact]
+    public async Task ResetPassword_UserNotFound_ReturnsFail()
+    {
+        // Arrange
+        var request = new ResetPasswordDto
+        {
+            Email = "unknown@example.com",
+            Token = "any",
+            NewPassword = "NewPassword123!"
+        };
+
+        _userManagerMock.Setup(um => um.FindByEmailAsync(request.Email))
+            .ReturnsAsync(null as User);
+
+        // Act
+        var result = await _authService.ResetPassword(request);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Message.Contains("User not found"));
+    }
+
+
+
     private void SetupSuccessfulLogin(LoginRequestDTO dto, User user)
     {
         _validator.Setup(v => v.ValidateAsync(dto, default))


### PR DESCRIPTION
✅ Functionality overview:

Added two new API endpoints:

POST /api/account/forgot-password

- Accepts an email address

- Generates a secure reset token using Identity

- Sends a reset link via email in the format:

https://localhost:5002/reset-password?token=<token>&email=<email>

POST /api/account/reset-password

- Accepts token, email, and new password

- Verifies token and resets the password via UserManager.ResetPasswordAsync

⚠️ Testing instructions (for development):

Since there is no frontend yet, follow these steps to test the reset:

Use Swagger or Postman to call:

POST /api/account/forgot-password
{
  "email": "your_email@example.com"
}

You will receive a reset link via email (from the no-reply Gmail account).

Open the link, copy the token and email from the URL parameters.

Important:
The token in the URL is URL-encoded.
You must decode it before using in the next request.
Use this site to decode the token:
👉 https://www.urldecoder.org/

Call:

    POST /api/account/reset-password
    {
      "email": "your_email@example.com",
      "token": "decoded_token_here",
      "newPassword": "YourNewPassword123!"
    }


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
